### PR TITLE
Delay shallow water conversion during soft resets, and replaces crashed ship

### DIFF
--- a/freeplay.lua
+++ b/freeplay.lua
@@ -221,7 +221,6 @@ local on_player_created = function(event)
 		
 		reset_global_settings()
 
-		chart_starting_area()
 		--	map_gen_1()
 
 		if not global.disable_crashsite then
@@ -243,7 +242,6 @@ local on_player_respawned = function(event)
 	-- CR-someday: Ideally, we should not be using the [on_player_respawned] event to chart the starting area.
 	-- Probobly should implement a delayed execution processor to handle things like this a bit cleaner.
 	if global.tick_to_start_charting_spawn ~= nil and game.tick >= global.tick_to_start_charting_spawn then
-		chart_starting_area()
 		global.tick_to_start_charting_spawn = nil
 	end
 end
@@ -569,6 +567,8 @@ script.on_nth_tick(60, function()
 		for chunk in surface.get_chunks() do
 			convert_shallow_water_in_area(chunk.area)	
 		end
+
+		chart_starting_area()
 	end
 end)
 

--- a/freeplay.lua
+++ b/freeplay.lua
@@ -340,9 +340,9 @@ end
 local on_surface_cleared = function(event)
 	local surface = game.surfaces[1]
 	--	game.forces["enemy"].kill_all_units()
-		surface.request_to_generate_chunks({0, 0}, 6)
-		surface.force_generate_chunk_requests()
-		crash_site.create_crash_site(surface, {-5,-6}, util.copy(global.crashed_ship_items), util.copy(global.crashed_debris_items), util.copy(global.crashed_ship_parts))
+	surface.request_to_generate_chunks({0, 0}, 6)
+	surface.force_generate_chunk_requests()
+	crash_site.create_crash_site(surface, {-5,-6}, util.copy(global.crashed_ship_items), util.copy(global.crashed_debris_items), util.copy(global.crashed_ship_parts))
 
 	-- Spawning an explosive cannon shell used to be called to kill players at
 	-- (0,0). This is no longer needed due to players being killed during

--- a/freeplay.lua
+++ b/freeplay.lua
@@ -340,9 +340,9 @@ end
 local on_surface_cleared = function(event)
 	local surface = game.surfaces[1]
 	--	game.forces["enemy"].kill_all_units()
-	--	surface.request_to_generate_chunks({0, 0}, 6)
-	--	surface.force_generate_chunk_requests()
-	--	crash_site.create_crash_site(surface, {-5,-6}, util.copy(global.crashed_ship_items), util.copy(global.crashed_debris_items), util.copy(global.crashed_ship_parts))
+		surface.request_to_generate_chunks({0, 0}, 6)
+		surface.force_generate_chunk_requests()
+		crash_site.create_crash_site(surface, {-5,-6}, util.copy(global.crashed_ship_items), util.copy(global.crashed_debris_items), util.copy(global.crashed_ship_parts))
 
 	-- Spawning an explosive cannon shell used to be called to kill players at
 	-- (0,0). This is no longer needed due to players being killed during

--- a/freeplay.lua
+++ b/freeplay.lua
@@ -4,7 +4,6 @@ local crash_site = require("crash-site")
 local SHALLOW_WATER_CONVERSION_DELAY = 300
 
 global.restart = "false"
-global.tick_to_start_charting_spawn = nil
 global.converted_shallow_water = false
 
 global.latch = 0
@@ -238,12 +237,6 @@ end
 
 local on_player_respawned = function(event)
 	handle_player_created_or_respawned(event.player_index)
-
-	-- CR-someday: Ideally, we should not be using the [on_player_respawned] event to chart the starting area.
-	-- Probobly should implement a delayed execution processor to handle things like this a bit cleaner.
-	if global.tick_to_start_charting_spawn ~= nil and game.tick >= global.tick_to_start_charting_spawn then
-		global.tick_to_start_charting_spawn = nil
-	end
 end
 -----------------------------------------ID 1--------------------------------------------------------
 function f_location()
@@ -365,7 +358,6 @@ function reset(reason)
 		change_seed()
 		game.surfaces[1].clear(true)
 		game.forces["player"].reset()
-		global.tick_to_start_charting_spawn = game.tick + 1
 	end
 
 	if reason ~= nil then

--- a/freeplay.lua
+++ b/freeplay.lua
@@ -1,7 +1,7 @@
 local util = require("util")
 local crash_site = require("crash-site")
 
-local SHALLOW_WATER_CONVERSION_DELAY = 300
+local SHALLOW_WATER_CONVERSION_DELAY = 60
 
 global.restart = "false"
 global.converted_shallow_water = false

--- a/freeplay.lua
+++ b/freeplay.lua
@@ -68,7 +68,51 @@ local ship_parts = function()
 	return crash_site.default_ship_parts()
 end
 
-local chart_starting_area =  change_seed = function()
+local chart_starting_area = function()
+	local r = global.chart_distance or 200
+	local force = game.forces.player
+	local surface = game.surfaces[1]
+	local origin = force.get_spawn_position(surface)
+	force.chart(surface, {{origin.x - r, origin.y - r}, {origin.x + r, origin.y + r}})
+end
+
+-----------------------------------------------------------------------------------------------------------------
+local map_gen_1 = function()
+	local surface = game.surfaces[1]
+	local iron = "iron-ore"
+	local copper = "copper-ore"
+	local coal = "coal"
+	local stone = "stone"
+	local oil = "crude-oil"
+	local uranium = "uranium-ore"
+	local enemy = "enemy-base"
+	local mgs = surface.map_gen_settings
+	mgs.water = "1"
+	mgs.terrain_segmentation = "1"
+	mgs.autoplace_controls[iron].size = "10"
+	mgs.autoplace_controls[iron].frequency = "1"
+	mgs.autoplace_controls[iron].richness = "1"
+	mgs.autoplace_controls[copper].size = "10"
+	mgs.autoplace_controls[copper].frequency = "1"
+	mgs.autoplace_controls[copper].richness = "1"
+	mgs.autoplace_controls[coal].size = "10"
+	mgs.autoplace_controls[coal].frequency = "1"
+	mgs.autoplace_controls[coal].richness = "1"
+	mgs.autoplace_controls[stone].size = "10"
+	mgs.autoplace_controls[stone].frequency = "1"
+	mgs.autoplace_controls[stone].richness = "1"
+	mgs.autoplace_controls[oil].size = "10"
+	mgs.autoplace_controls[oil].frequency = "10"
+	mgs.autoplace_controls[oil].richness = "0.05"
+	mgs.autoplace_controls[uranium].size = "4"
+	mgs.autoplace_controls[uranium].frequency = "0.1"
+	mgs.autoplace_controls[uranium].richness = "1"
+	mgs.autoplace_controls[enemy].size = "6"
+	mgs.autoplace_controls[enemy].frequency = "1"
+	surface.map_gen_settings = mgs
+end
+
+local change_seed = function()
 	local surface = game.surfaces[1]
 	local mgs = surface.map_gen_settings
 	mgs.seed = math.random(1111,999999999)

--- a/freeplay.lua
+++ b/freeplay.lua
@@ -68,51 +68,7 @@ local ship_parts = function()
 	return crash_site.default_ship_parts()
 end
 
-local chart_starting_area = function()
-	local r = global.chart_distance or 200
-	local force = game.forces.player
-	local surface = game.surfaces[1]
-	local origin = force.get_spawn_position(surface)
-	force.chart(surface, {{origin.x - r, origin.y - r}, {origin.x + r, origin.y + r}})
-end
-
------------------------------------------------------------------------------------------------------------------
-local map_gen_1 = function()
-	local surface = game.surfaces[1]
-	local iron = "iron-ore"
-	local copper = "copper-ore"
-	local coal = "coal"
-	local stone = "stone"
-	local oil = "crude-oil"
-	local uranium = "uranium-ore"
-	local enemy = "enemy-base"
-	local mgs = surface.map_gen_settings
-	mgs.water = "1"
-	mgs.terrain_segmentation = "1"
-	mgs.autoplace_controls[iron].size = "10"
-	mgs.autoplace_controls[iron].frequency = "1"
-	mgs.autoplace_controls[iron].richness = "1"
-	mgs.autoplace_controls[copper].size = "10"
-	mgs.autoplace_controls[copper].frequency = "1"
-	mgs.autoplace_controls[copper].richness = "1"
-	mgs.autoplace_controls[coal].size = "10"
-	mgs.autoplace_controls[coal].frequency = "1"
-	mgs.autoplace_controls[coal].richness = "1"
-	mgs.autoplace_controls[stone].size = "10"
-	mgs.autoplace_controls[stone].frequency = "1"
-	mgs.autoplace_controls[stone].richness = "1"
-	mgs.autoplace_controls[oil].size = "10"
-	mgs.autoplace_controls[oil].frequency = "10"
-	mgs.autoplace_controls[oil].richness = "0.05"
-	mgs.autoplace_controls[uranium].size = "4"
-	mgs.autoplace_controls[uranium].frequency = "0.1"
-	mgs.autoplace_controls[uranium].richness = "1"
-	mgs.autoplace_controls[enemy].size = "6"
-	mgs.autoplace_controls[enemy].frequency = "1"
-	surface.map_gen_settings = mgs
-end
-
-local change_seed = function()
+local chart_starting_area =  change_seed = function()
 	local surface = game.surfaces[1]
 	local mgs = surface.map_gen_settings
 	mgs.seed = math.random(1111,999999999)
@@ -694,7 +650,7 @@ local on_biter_base_built = function(event)
 	end
 	create_worm()
 	if (oxpos > -32 and oxpos < 32 and oypos > -32 and oypos < 32) then
-		reset("Biters have nested at spawn!")
+		reset("Uh oh... The biters have overtaken your spawn!")
 	end
 end
 ---------------------------------------------------------------------------------------------------------------------------------------------------

--- a/freeplay.lua
+++ b/freeplay.lua
@@ -211,6 +211,11 @@ local reset_global_settings__post_surface_clear = function()
 
 end
 
+local reset_global_settings = function ()
+	reset_global_setings__pre_surface_clear()
+	reset_global_settings__post_surface_clear()
+end
+
 local handle_player_created_or_respawned = function(player_index)
 	local player = game.get_player(player_index)
 


### PR DESCRIPTION
This seems to be fixing the issue on the testing server reliably.
Rather have this merged sooner rather than later to prevent conflicts.